### PR TITLE
Fix the translation test

### DIFF
--- a/tests/TranslateTest.php
+++ b/tests/TranslateTest.php
@@ -9,7 +9,7 @@ class TranslateTest extends TestCase
      */
     public function testTranslation()
     {
-        $translation = trans('general.ok');
+        $translation = trans('general.ok', 'en');
 
         $this->assertEquals('Ok', $translation);
     }
@@ -29,7 +29,7 @@ class TranslateTest extends TestCase
      */
     public function testTranslationFormatting()
     {
-        $translation = trans('general.greet_user', null, 'Tester');
+        $translation = trans('general.greet_user', 'en', 'Tester');
 
         $this->assertEquals('Hello, Tester!', $translation);
     }
@@ -40,6 +40,6 @@ class TranslateTest extends TestCase
      */
     public function testMissingTranslation()
     {
-        trans('1337.never.gonna.give.you.up');
+        trans('1337.never.gonna.give.you.up', 'en');
     }
 }


### PR DESCRIPTION
## What

I've noticed, the test was expecting the system language to be english... That's rather selfish, there fore I've chosen to enforce the `en` locales for the tests.
## How to review

Change your `LANG` environment variable, from `en_XXXXX` to something else, like `fr_XXXXX`. Run the tests on current master branch and then on this fixed branch. The tests should now pass.
## Who can review

Preferably, @DamianBronczyk 
